### PR TITLE
docs: Refine text for clarity in lab2.adoc

### DIFF
--- a/modules/ROOT/pages/lab2.adoc
+++ b/modules/ROOT/pages/lab2.adoc
@@ -17,7 +17,7 @@
 
 == Internal buttons
 
-The nRF52840 DK board has five buttons. The button set off by itself resets the board. The four buttons in a cluster are ones available for use in our code. On the board they have labels BUTTON1 through BUTTON4, but their aliases in code are `sw0` through `sw3`. If you have not encountered it before, _sw_ is a common abbreviation for _switch_ in electronics.
+The nRF52840 DK board has five buttons. The button not near the other four resets the board when pressed. The four buttons in a cluster are ones available for use in our code. On the board they have labels BUTTON1 through BUTTON4, but their aliases in code are `sw0` through `sw3`. If you have not encountered it before, _sw_ is a common abbreviation for _switch_ in electronics.
 
 . Create a new application called `led-enabler`.
 . Enter the following code into `main.c`.
@@ -66,7 +66,7 @@ int main(void) {
 <3> A integer variable is declared to hold the state of the button.
 <4> Although it was not done in the xref:lab1.adoc[Lab 1] examples, it is best practice to always check that peripherals are ready before attempting to use them. The function `gpio_is_ready_dt` returns `true` if the specified GPIO pin is ready. The code that follows in the curly braces will only be executed if the GPIO pin connected to the LED is ready for use.
 <5> The `else` statement marks the beginning of code that will be executed if `gpio_is_ready_dt` returns `false`.
-<6> The `return` command causes the `main` function to be exited, sending a value of -1 to the kernel (the code that called `main` at startup). A return value of 0 is usually used to signal success and negative values indicate various types of errors.
+<6> The `return` command causes the `main` function to be exited, sending a value of -1 to the kernel (the code that called `main` at startup). A return value of 0 is usually used to signal success and other values indicate various types of errors.
 <7> The pin connected to BUTTON1 is configured as an input.
 <8> The state of the button is read and its value (0 for released and 1 for pressed) is saved in the variable `btn_pressed`.
 <9> The LED is set to have the same value as the button (on if pressed, off if released).
@@ -84,16 +84,16 @@ LEDs are also unidirectional devices.  That is, they have a preferred direction 
 Construct the circuit shown in <<img-circuit1-breadboardview>> on your breadboard. The ground connection (one of the header sockets marked **GND** on the development board) should be connected to the bus strip that is marked with the blue (or black, depending on the breadboard manufacturer) line.  We will be consistent about doing this throughout the course because it will make debugging your circuits easier (and it is the convention in this field).  The apparent lengths of the LED legs in this diagram are solely due to how far they had to travel to reach their proper holes.  So, even though it appears that a longer leg is attached to the ground bus strip, that is not the case.  The *short* leg of each LED should be connected to the ground bus.
 
 [#img-circuit1-breadboardview]
-.View of the breadboard for the two LED circuit.
+.View of the breadboard for the two-LED circuit.
 image::lab2/two-led-breadboard-view.png[Breadboard view of circuit 1,605,331]
 
 Professionals would never draw a picture like <<img-circuit1-breadboardview>> to show how a circuit is connected.  Instead, a more abstract circuit diagram would be used. The diagram in <<img-circuit1-diagram>> is how they would draw this circuit.
 
 [#img-circuit1-diagram]
-.Circuit diagram for the two LED circuit.
+.Circuit diagram for the two-LED circuit.
 image::lab2/two-led-circuit-diagram.png[Circuit diagram for circuit 1,282,263]
 
-Assembly this circuit on the breadboard.
+Assemble this circuit on the breadboard.
 
 === Application code and hardware overlay 
 
@@ -167,7 +167,7 @@ image::lab2/nrf-connect-generate-2026.png[Generate only,542,285]
 ----
 <1> We are adding entries to the `leds` section of the devicetree for this board.
 <2> Our first new entry is a subnode with the name `led_4` and a label of `red_led`.
-<3> The red LED will be connected to P0.29. P0 is short for GPIO port 0, which in this code is identified by `&gpio0`. This is pin 29 connected to that port. The LED will be lit when the output of this pin is the high voltage state (around 3 V).
+<3> The red LED will be connected to `P0.29`. P0 is short for GPIO port 0, which in this code is identified by `&gpio0`. This is pin 29 connected to that port. The LED will be lit when the output of this pin is the high voltage state (around 3 V).
 <4> Defining the alias that will be used to access this using `DT_ALIAS` in `main.c`.
 +
 . You now want to perform a **pristine build** (a more complete build process that is required after altering the devicetree description of the hardware). The pristine build option can be found in the **Actions** section of the nRF Connect side panel. Hovering over **Build** will reveal the pristine build icon (a circular arrow) on the right. Click on this icon.


### PR DESCRIPTION
* Changed a button being described as "set off", as that phrase is often used to mean it's been activated, whereas here it was meant to mean that it is simply physically separated
* Updated footnote text for return values to reflect that positive values (generally) also represent error states
* Other minor changes: fixed typos, adjusted formatting